### PR TITLE
Add tolerations for all nodes

### DIFF
--- a/docs/missing-container-metrics/templates/daemon-set.yaml
+++ b/docs/missing-container-metrics/templates/daemon-set.yaml
@@ -34,6 +34,8 @@ spec:
         hostPath:
           path: /run/containerd/containerd.sock
       {{- end }}
+      tolerations:
+      - operator: exists
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
This adds toleration to daemonset that will allow it to run on all nodes, even those with taints.